### PR TITLE
【不具合修正】処理の起動トリガーを特定のクラス名に依存させない

### DIFF
--- a/background.js
+++ b/background.js
@@ -168,7 +168,7 @@ var sub_observer = new MutationObserver(rewrite_message);
 var main_observer = new MutationObserver(create_sub_observer);
 
 function create_sub_observer(){
-  load_container('.sc-dphlzf, .hnKbti', function (sub_container) {
+  load_container('#_timeLine > div', function (sub_container) {
 
     //サブ要素（チャット内でのメッセージロード時に変化）
     sub_observer.disconnect();
@@ -304,7 +304,8 @@ window.onload = function(){
   // onload → div要素ロード → オブザーバーset → サブオブザーバーset → rewrite_message実行
   //メイン要素を取得して結果をコールバック関数の引数に渡す
   //要素が取得できるまで待機して実行される
-  load_container('.sc-epGmkI, .cMoFQn', function (main_container) {
+  load_container('#_chatContent', function (main_container) {
+
     // 初回起動時に説明画面を表示する
     view_initial_explanation();
 

--- a/background.js
+++ b/background.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2020 メープル＠ペンギン会員 All rights reserved.
 
 // 初期設定のロード
+var account_id = 0
 var setting = {
   'line_count_repry': 1,
   'line_count_long_sentences': 5,
@@ -104,7 +105,6 @@ function rewrite_message(){
     return false
   }
   $(function(){
-    var my_aid = $('#_myStatusIcon').find('img').data('aid');
     // _messageIdから始まるid要素を取得
     $("[id^='_messageId']").each(function(){
       //既に処理済みのメッセージの場合は処理除外する/未処理ならフラグ追加
@@ -114,7 +114,7 @@ function rewrite_message(){
       mark_as_processed($(this));
 
       // 自分の投稿メッセージは処理除外
-      if( $(this).find('._avatarHoverTip').data('aid') == my_aid ){
+      if( $(this).find('._avatarHoverTip').data('aid') == account_id ){
         return true;
       }
 
@@ -311,6 +311,9 @@ window.onload = function(){
 
     // メニューを描画する
     draw_tool_menu();
+
+    // 省略処理の判定に利用するaccount_idを取得しておく
+    account_id = $("#_accountId").text();
 
     //監視の開始 メイン要素（チャット切り替え時に変化）
     main_observer.disconnect();

--- a/background.js
+++ b/background.js
@@ -119,9 +119,13 @@ function rewrite_message(){
       }
 
       // 自分宛てに通知された場合は処理除外する
-      // [class 仕様] 通知ありTO : fzprrx / 通知ありRE : xnqWz
-      // [class 仕様 ダークモード] 通知ありTO : fqBBek / 通知ありRE : yVguV
-      if( $(this).hasClass('xnqWz') || $(this).hasClass('fzprrx') || $(this).hasClass('fqBBek') || $(this).hasClass('yVguV') ){
+      // 正規表現にて下記パターンの一致を判定する
+      // TOALL : data-cwtag="[toall]"
+      // 自分宛てRe : data-cwtag="[rp aid=(account_id) to=**********]"
+      // 自分宛てTo : data-cwtag="[To:(account_id)]"
+      var data_cwtag = $(this).find('pre').find('div').data('cwtag');
+      var regex = RegExp(account_id+'|toall')
+      if( data_cwtag && data_cwtag.match(regex) ){
         return true;
       }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "chatwork表示スッキリツール",
   "description": "chatworkでメッセージが流れてしまう現象を解決します。長文メッセージと他人宛の返信メッセージを省略表示します。",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "icons": {
       "16": "img/icon16.png",
       "48": "img/icon48.png",


### PR DESCRIPTION
# 概要
8月10日〜8月13日にかけて発生したツールが起動しない不具合について
障害報告と修正内容を纏めます。

# 障害報告
## 状況

| サマリー |  |
|---|---|
| 発生した事象 | 一時的にツールによる省略処理が実行されず、メニューアイコンも表示されなかった |
| 発生した時刻 | 推定：2020-08-10 05:00:00 ~ 2020-08-13 15:00:00 （現在） |
| 影響ユーザー数 | 推定 234 名（現時点でのインストール済み全ユーザー） |
| 原因 | Chatworkの仕様変更により処理が起動できなくなった |
| 一次対応 | ・自身の環境で動作確認<br/>・他ユーザへの影響調査<br/>・一部ユーザーへアナウンス |
| 根本対応 | 本PRにて対応（詳細は修正内容参照） |

# 修正内容

### 原因
   - 本ツールはチャットデータが画面描画されてから省略処理を実行する仕組みになっている
   - load_container 関数の指定要素が読み込まれるまで処理を保留している
   - 要素を指定する際にクラス名を利用していた
   - このクラス名がChatworkの仕様変更により変更されてload_containerが待機ループになっていた
     - その後に実行されるハズの省略処理やメニュー描画が実行されなかった

### 対応
   - load_container 関数の指定要素を正しく取得できるようにする

### 再発防止
   - クラス名が乱数文字列で作られており頻繁に変更される可能性が考えられる
   - クラス名ではなく意味のあるIDや要素名をトリガーに変更する
   - 他の処理も乱数文字列のクラス依存がある場合は除去しておく

| 修正commit | 内容 |
|---|---|
| [ツールが起動しない不具合を修正](https://github.com/maple-invest/chatwork_extension/commit/7ff5656a36afd517815ac740d803a60c6cb11609) | 起動に関わる load_container 関数の要素指定を正しく取得できるように変更 |
| [アカウントIDの取得方法をリファクタ](https://github.com/maple-invest/chatwork_extension/commit/7d63ebc491fea2a1e0d9352ca8645efd858b1ea2) | アカウントID取得の方法がChatworkのクラス階層に依存していたので修正<br/>また、後述の修正を容易にする為の準備 |
| [処理除外の判定ロジックのクラス名依存を逓減](https://github.com/maple-invest/chatwork_extension/commit/3e8d198dae12ec7055aa93711a2a13c7346c6cfa) | ToやRe等の通知がある投稿の処理除外でもクラス名への依存があったので修正 |

# 障害振り返り

 - 問題発生から検知までの時間が遅い
   - 障害検知の仕組みが存在しない
     - Chatworkに依存している仕様について変更を監視する仕組みが必要
     - 自動テストツールのような物で定期的に確認したい
   - 例外処理の仕組みが存在しない
     - ユーザーが異常を検知する術がない
     - 例外メッセージをコンソールに出力してもよいかなと思う
 - 依存性の排除について
   - Chatworkへの依存を排除する事はできないが最低限影響を抑える実装を心がける

実際には事業化されてないサービスに対して追加開発や監視リソースを支払う事が難しいので
問題が頻繁に再発するようであればコストに見合う対策を実施する予定